### PR TITLE
fix: add write permissions for opencode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -17,8 +17,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Fixes the permission error when opencode-agent[bot] tries to add comments to pull requests.

## Problem
The opencode workflow was missing `write` permissions for `pull-requests` and `issues`, causing the agent to fail with the error:
> User opencode-agent[bot] does not have write permissions

## Solution
Updated the permissions in `.github/workflows/opencode.yml`:
- Changed `pull-requests: read` → `pull-requests: write`
- Changed `issues: read` → `issues: write`

This allows the opencode agent to add comments when triggered by `/oc` commands.