### PR TITLE
fix: resolve remaining Kotlin compilation warnings

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/karczews/brainagator/tts/QueuedTextToSpeech.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/karczews/brainagator/tts/QueuedTextToSpeech.kt
@@ -83,19 +83,8 @@ abstract class QueuedTextToSpeech : TextToSpeech {
 
         val result = queue.trySend(job)
         if (result.isFailure) {
-            if (queue.isClosedForSend) {
-                Logger.w { "TTS queue closed, restarting..." }
-                startQueueProcessor()
-                // Retry once after restarting
-                val retryResult = queue.trySend(job)
-                if (retryResult.isFailure) {
-                    Logger.w { "TTS queue closed, cannot enqueue: $text" }
-                    job.cancel()
-                }
-            } else {
-                Logger.w { "TTS queue closed, cannot enqueue: $text" }
-                job.cancel()
-            }
+            Logger.w { "TTS queue closed, cannot enqueue: $text" }
+            job.cancel()
         }
         return job
     }

--- a/composeApp/src/commonMain/kotlin/io/github/karczews/brainagator/tts/QueuedTextToSpeech.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/karczews/brainagator/tts/QueuedTextToSpeech.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -63,12 +64,8 @@ abstract class QueuedTextToSpeech : TextToSpeech {
             }
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     override fun speak(text: String): Job {
-        if (queue.isClosedForSend) {
-            Logger.w { "TTS queue closed, restarting..." }
-            startQueueProcessor()
-        }
-
         val job =
             scope.launch(start = CoroutineStart.LAZY) {
                 try {
@@ -86,8 +83,19 @@ abstract class QueuedTextToSpeech : TextToSpeech {
 
         val result = queue.trySend(job)
         if (result.isFailure) {
-            Logger.w { "TTS queue closed, cannot enqueue: $text" }
-            job.cancel()
+            if (queue.isClosedForSend) {
+                Logger.w { "TTS queue closed, restarting..." }
+                startQueueProcessor()
+                // Retry once after restarting
+                val retryResult = queue.trySend(job)
+                if (retryResult.isFailure) {
+                    Logger.w { "TTS queue closed, cannot enqueue: $text" }
+                    job.cancel()
+                }
+            } else {
+                Logger.w { "TTS queue closed, cannot enqueue: $text" }
+                job.cancel()
+            }
         }
         return job
     }

--- a/composeApp/src/jsMain/kotlin/io/github/karczews/brainagator/tts/JsTextToSpeech.kt
+++ b/composeApp/src/jsMain/kotlin/io/github/karczews/brainagator/tts/JsTextToSpeech.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
 package io.github.karczews.brainagator.tts
 
 import androidx.compose.runtime.Composable
@@ -21,6 +23,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import io.github.karczews.brainagator.Logger
 import kotlinx.coroutines.CompletableDeferred
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsArray
 
 /**
  * JS implementation of Text-to-Speech using the Web Speech API.


### PR DESCRIPTION
## Summary

This PR fixes the remaining Kotlin compilation warnings that weren't addressed in PR #111.

## Changes

### 1. Fix DelicateCoroutinesApi Warning (`QueuedTextToSpeech.kt`)
- Added `@OptIn(DelicateCoroutinesApi::class)` annotation to suppress the warning for `Channel.isClosedForSend` usage
- Refactored the `speak()` method to handle queue restarts more robustly with retry logic

### 2. Fix ExperimentalWasmJsInterop Warnings (`JsTextToSpeech.kt`)
- Added `@file:OptIn(ExperimentalWasmJsInterop::class)` annotation at the file level
- This suppresses all 5 experimental API warnings for JS interop declarations:
  - `JsArray.length` access
  - `JsArray[]` indexing  
  - `utterance.voice` assignment
  - `getVoices()` return type

## Build Status

✅ All targets compile without Kotlin warnings:
- JVM: `compileKotlinJvm`
- Android: `compileAndroidMain`  
- Wasm: `compileKotlinWasmJs`
- JS: `compileKotlinJs`
- iOS: `compileKotlinIosArm64`, `compileKotlinIosSimulatorArm64`

## Remaining Warnings (External)

The following warnings are from external dependencies and cannot be addressed by us:
- Gradle task deprecations (`jvmRunHot`, `runCommonizer`) - Internal to Kotlin/Compose plugins
- Node.js deprecations (`url.parse()`, `punycode`) - External npm packages