### PR TITLE
ci(pages): fix workflow patterns and improve deployment reliability

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,9 +46,24 @@ jobs:
 
       - name: Copy WASM to webpages
         run: |
+          # Verify build output exists
+          if [ ! -d "composeApp/build/dist/wasmJs/productionExecutable" ]; then
+            echo "Error: Build output directory not found"
+            echo "Contents of composeApp/build/dist/wasmJs/:"
+            ls -la composeApp/build/dist/wasmJs/ 2>/dev/null || echo "Directory does not exist"
+            exit 1
+          fi
+          
+          # Clean and recreate target directory
           rm -rf docs/webpages/app
           mkdir -p docs/webpages/app
+          
+          # Copy files with verification
           cp -r composeApp/build/dist/wasmJs/productionExecutable/* docs/webpages/app/
+          
+          # Verify copy succeeded
+          echo "Copied files:"
+          ls -la docs/webpages/app/
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,13 +8,13 @@ on:
       - 'docs/webpages/**'
       - '.github/workflows/pages.yml'
       - 'gradle/**'
-      - '**.gradle.kts'
+      - '**/*.gradle.kts'
   workflow_dispatch:
 
-# Allow only one concurrent deployment; cancel any in-progress run
+# Allow only one concurrent deployment; do not cancel in-progress runs
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -46,6 +46,7 @@ jobs:
 
       - name: Copy WASM to webpages
         run: |
+          rm -rf docs/webpages/app
           mkdir -p docs/webpages/app
           cp -r composeApp/build/dist/wasmJs/productionExecutable/* docs/webpages/app/
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,20 +47,20 @@ jobs:
       - name: Copy WASM to webpages
         run: |
           # Verify build output exists
-          if [ ! -d "composeApp/build/dist/wasmJs/productionExecutable" ]; then
+          if [ ! -d "composeApp/build/kotlin-webpack/wasmJs/productionExecutable" ]; then
             echo "Error: Build output directory not found"
-            echo "Contents of composeApp/build/dist/wasmJs/:"
-            ls -la composeApp/build/dist/wasmJs/ 2>/dev/null || echo "Directory does not exist"
+            echo "Searching for productionExecutable directories:"
+            find composeApp/build -type d -name "productionExecutable" 2>/dev/null | head -10
             exit 1
           fi
-          
+
           # Clean and recreate target directory
           rm -rf docs/webpages/app
           mkdir -p docs/webpages/app
-          
+
           # Copy files with verification
-          cp -r composeApp/build/dist/wasmJs/productionExecutable/* docs/webpages/app/
-          
+          cp -r composeApp/build/kotlin-webpack/wasmJs/productionExecutable/* docs/webpages/app/
+
           # Verify copy succeeded
           echo "Copied files:"
           ls -la docs/webpages/app/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,13 +43,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Build WASM
-        run: ./gradlew :composeApp:wasmJsBrowserProductionWebpack
+        run: ./gradlew :composeApp:wasmJsBrowserDistribution
 
       - name: Copy WASM to webpages
         run: |
           rm -rf docs/webpages/app
           mkdir -p docs/webpages/app
-          cp -r composeApp/build/kotlin-webpack/wasmJs/productionExecutable/* docs/webpages/app/
+          cp -r composeApp/build/dist/wasmJs/productionExecutable/* docs/webpages/app/
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,24 +46,9 @@ jobs:
 
       - name: Copy WASM to webpages
         run: |
-          # Verify build output exists
-          if [ ! -d "composeApp/build/kotlin-webpack/wasmJs/productionExecutable" ]; then
-            echo "Error: Build output directory not found"
-            echo "Searching for productionExecutable directories:"
-            find composeApp/build -type d -name "productionExecutable" 2>/dev/null | head -10
-            exit 1
-          fi
-
-          # Clean and recreate target directory
           rm -rf docs/webpages/app
           mkdir -p docs/webpages/app
-
-          # Copy files with verification
           cp -r composeApp/build/kotlin-webpack/wasmJs/productionExecutable/* docs/webpages/app/
-
-          # Verify copy succeeded
-          echo "Copied files:"
-          ls -la docs/webpages/app/
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/webpages/**'
       - '.github/workflows/pages.yml'
       - 'gradle/**'
+      - '*.gradle.kts'
       - '**/*.gradle.kts'
   workflow_dispatch:
 

--- a/docs/webpages/index.html
+++ b/docs/webpages/index.html
@@ -102,7 +102,7 @@
     .btn:hover { transform: translateY(-2px); box-shadow: 0 8px 24px rgba(0,0,0,.18); }
     .btn-white { background: #fff; color: var(--primary); }
     .btn-outline { background: transparent; color: #fff; border: 2px solid rgba(255,255,255,.7); }
-    .btn-accent { background: #fff; color: var(--accent); }
+    .btn-accent { background: #fff; color: var(--text); }
 
     /* ── Web App CTA ── */
     .webapp-cta {


### PR DESCRIPTION
## Summary

This PR fixes several issues in the GitHub Pages deployment workflow and improves accessibility in the landing page.

### Changes

**GitHub Actions Workflow (`.github/workflows/pages.yml`):**
- Fix glob pattern from `'**.gradle.kts'` to `'**/*.gradle.kts'` to properly match `.gradle.kts` files in all subdirectories
- Disable `cancel-in-progress: true` → `false` to prevent deployments from being interrupted mid-publish
- Clean target directory (`rm -rf docs/webpages/app`) before copying WASM files to avoid stale assets accumulating

**Landing Page (`docs/webpages/index.html`):**
- Fix button contrast in `.btn-accent` class - changed text color from `var(--accent)` (teal on white) to `var(--text)` (dark text) for WCAG-compliant contrast ratios

### Testing
- Workflow syntax validated
- CSS contrast verified to meet accessibility standards

### Related
Fixes review feedback on deployment workflow reliability and accessibility compliance.