### PR TITLE
ci(android-release): automate versioning during build

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -29,7 +29,10 @@ jobs:
 
       - name: Write version name
         run: |
-          VERSION_NAME=$(git describe --tags --abbrev=0)
+          if ! VERSION_NAME=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null); then
+            echo "::error::No release tag found (expected format: vX.Y.Z)."
+            exit 1
+          fi
           echo "app.versionName=${VERSION_NAME#v}" >> gradle.properties
 
       - name: Build release APK

--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -21,6 +23,14 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+
+      - name: Write version code
+        run: echo "app.versionCode=$GITHUB_RUN_NUMBER" >> gradle.properties
+
+      - name: Write version name
+        run: |
+          VERSION_NAME=$(git describe --tags --abbrev=0)
+          echo "app.versionName=${VERSION_NAME#v}" >> gradle.properties
 
       - name: Build release APK
         uses: ./.github/actions/android-release

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -25,8 +25,8 @@ android {
             libs.versions.android.targetSdk
                 .get()
                 .toInt()
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = project.property("app.versionCode").toString().toInt()
+        versionName = project.property("app.versionName").toString()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ org.gradle.caching=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 app.versionCode=5
-app.versionName=v0.7.0
+app.versionName=0.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,5 @@ org.gradle.caching=true
 #Android
 android.nonTransitiveRClass=true
 android.useAndroidX=true
+app.versionCode=5
+app.versionName=v0.7.0


### PR DESCRIPTION
## Summary

Automate `versionCode` and `versionName` derivation during the Android release workflow, eliminating manual version bumps.

## Changes

- **`.github/workflows/android-release-build.yml`**: fetch full git history (`fetch-depth: 0`), add steps to write `app.versionCode` from `$GITHUB_RUN_NUMBER` and `app.versionName` from the latest git tag (stripping the `v` prefix).
- **`androidApp/build.gradle.kts`**: read `versionCode` and `versionName` from Gradle properties instead of hardcoded values.
- **`gradle.properties`**: add `app.versionCode` and `app.versionName` entries used during local development.