### PR TITLE
fix(ui): replace removeFirst call for Android 14 compatibility

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/karczews/brainagator/ui/screens/games/numberorder/NumberOrderGameScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/karczews/brainagator/ui/screens/games/numberorder/NumberOrderGameScreen.kt
@@ -114,7 +114,7 @@ fun NumberOrderGameScreen(
             Logger.d { "Number clicked: ${gameNumber.number}, gameNumbersInOrder=$gameNumbersInOrder" }
             val nextNumber = gameNumbersInOrder.firstOrNull()
             if (nextNumber != null && gameNumber.number == nextNumber) {
-                gameNumbersInOrder.removeFirst()
+                gameNumbersInOrder.removeAt(0)
                 gameNumbers.remove(gameNumber)
                 val position = gameNumbers.indexOfLast { it.matched } + 1
                 gameNumbers.add(position, gameNumber.copy(matched = true))


### PR DESCRIPTION
## Summary
- replace the removeFirst() call in NumberOrderGameScreen with removeAt(0)
- avoid the Kotlin/JDK method conflict that can crash the app on Android 14 and earlier

## Testing
- ./gradlew ktlintCheck detekt

## Notes
- the PR only includes the committed NumberOrderGameScreen.kt change
- local untracked .opencode/ content was left out of the PR